### PR TITLE
Non overlapping intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ Lets try 75 coding problems in python
 26. House Robber 2
 27. Min Stack
 28. Merge Intervals
+29. Non overlapping Intervals.
 

--- a/non-overlapping-intervals/non-overlapping-intervals.py
+++ b/non-overlapping-intervals/non-overlapping-intervals.py
@@ -1,0 +1,30 @@
+# The decision to keep the interval with the smaller end time (by moving the left pointer to right) is a key strategy to minimize future overlaps.
+class Solution:
+    def eraseOverlapIntervals(self, intervals: List[List[int]]) -> int:
+        # if we have only 1 interval, it is a non overlapping interval
+        if len(intervals) == 1: 
+            return 0
+
+        # sort the intervals based on the start
+        intervals.sort(key = lambda i : i[0])
+        result = 0    
+        left, right = 0, 1
+
+        while right < len(intervals):
+            # start of current interval is less than end of interval corresponding to left
+            if intervals[right][0] < intervals[left][1]:
+                result += 1
+                if intervals[left][1] > intervals[right][1]:
+                    # keep the left pointer on an interval which has a lower end time
+                    # this will ensure that out of the overlapping intervals, the 
+                    # interval will the larger end time is eliminated
+                    # larger end time will lead to more overlapping between remaining intervals
+                    left = right
+
+            else:
+                left = right    
+
+            right += 1
+
+        return result    
+        


### PR DESCRIPTION
Goal is to remove minimum number of intervals such that the remaining intervals are non overlapping.

1. Sort the input intervals based on the start time of each interval.
2. When there is an overlap (start of 2nd < end of 1st) then we will keep the interval which has a min end time from both the overlapping intervals. This will ensure that there are less chances of overlap with future intervals. 
3. For example : [1, 7] [3, 10]. These 2 intervals are overlapping. Here we will retain the first interval and discard the second interval. This will make sure that any subsequent intervals [7, x] [8, x] [9, x] are non overlapping
4. Maintaining 2 pointers is the key here