### PR TITLE
Binary tree level order traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ Lets try 75 coding problems in python
 32. Group Anagrams.
 33. Length of the longest increasing subsequence.
 34. Length of the longest consecutive sequence.
+35. Binary Tree level order traversal.
 

--- a/binary-tree-level-order-traversal/binary-tree-level-order-traversal.py
+++ b/binary-tree-level-order-traversal/binary-tree-level-order-traversal.py
@@ -1,0 +1,52 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+
+    def levelOrder(self, root: Optional[TreeNode]) -> List[List[int]]:
+        # if tree does not exist
+        if not root:
+            return []
+
+        results = []
+
+        # for level order traversal a.k.a BFS we will need a queue
+        # we will start by adding the root element to the queue
+        # at every level we will pop all the elements from that level from the queue
+        # at every level we will also keep on adding the left and right children of the elements to the queue.
+
+        queue = collections.deque()
+        queue.append(root)
+
+        # we will continue to iterate while we have no elements to look for at the current level
+        while queue:
+            # queue length at this level will signify the number of elements on this level
+            queueLength = len(queue)
+            level = [] # list to store the values of all the elements at the current level
+
+            # we will pop all the elements that are present at the current level
+            for i in range(queueLength):
+                # pop from the queue
+                currentNode = queue.popleft()
+
+                # if the current element is not None then we will add the value to level list
+                # additionally we will also add the left and right children to the queue
+
+                if currentNode:
+                    level.append(currentNode.val)
+                    queue.append(currentNode.left)
+                    queue.append(currentNode.right)
+
+
+            # once we have iterated all the elements at the current level we will add level list to results
+            if level:
+                results.append(level)
+
+
+        return results
+
+
+        


### PR DESCRIPTION
Level order traversal also referred to as Breadth first search is executed using a queue. 
Initially we start by adding the root element to the queue. 
During each level traversal, we will remove the elements from the queue corresponding to that level. This will be achieved by checking the queue length before we start removing the elements. 
